### PR TITLE
External getters helper: Parser auto management

### DIFF
--- a/src/classes/Parser.ts
+++ b/src/classes/Parser.ts
@@ -66,6 +66,14 @@ export default class Parser {
   }
 
   /**
+   * Clone this Parser instance
+   * Keep only path and pre-processors
+   */
+  clone(): Parser {
+    return new Parser(this.path, this.preprocessors)
+  }
+
+  /**
    * Merge parsing options with default Parser options
    */
   mergeOptions(

--- a/src/classes/Parser.ts
+++ b/src/classes/Parser.ts
@@ -20,9 +20,34 @@ export default class Parser {
 
   preprocessors: Array<Preprocessor>
 
+  /**
+   * List of absolute files path parsed by this Parser instance
+   */
+  readonly parsedFiles: Array<string> = []
+
   constructor(extractedArchivePath: string, preprocessors: Array<Preprocessor> = []) {
     this.path = extractedArchivePath
     this.preprocessors = preprocessors
+  }
+
+  /**
+   * Save given path in parsed file list by avoiding duplicate entries
+   */
+  private savePath(absolutePath: string): void {
+    if (!this.parsedFiles.includes(absolutePath)) {
+      this.parsedFiles.push(absolutePath)
+    }
+  }
+
+  /**
+   * Resolve path relative to the archive root and save it in parsed file list
+   */
+  private resolveAndSavePath(relativePath: string): string {
+    const absolutePath = this.resolveRelativePath(relativePath)
+
+    this.savePath(absolutePath)
+
+    return absolutePath
   }
 
   /**
@@ -76,6 +101,7 @@ export default class Parser {
    * Parse directory files recursively from given path for any supported file format
    */
   async parseDir(relativeDirPath: string, options?: OptionsParseDir): Promise<Array<Record<string, any>>> {
+    // TODO: implement parsed files saving
     return parseDir(this.resolveRelativePath(relativeDirPath), this.mergeOptions(options))
   }
 
@@ -84,7 +110,7 @@ export default class Parser {
    * Throw error if can't access file or if parsing fail
    */
   async parseFile<T = any>(relativeFilePath: string, options?: OptionsParseFile & PreprocessorOptions): Promise<T> {
-    return parseFile<T>(this.resolveRelativePath(relativeFilePath), this.mergeOptions(options))
+    return parseFile<T>(this.resolveAndSavePath(relativeFilePath), this.mergeOptions(options))
   }
 
   /**
@@ -95,7 +121,7 @@ export default class Parser {
     const mergedOptions = this.mergeOptions(options)
 
     return parseAsText(
-      Pipeline.fromFile(this.resolveRelativePath(relativeFilePath), mergedOptions.preprocessors),
+      Pipeline.fromFile(this.resolveAndSavePath(relativeFilePath), mergedOptions.preprocessors),
       mergedOptions,
     )
   }
@@ -111,7 +137,7 @@ export default class Parser {
     const mergedOptions = this.mergeOptions(options)
 
     return parseAsJSON(
-      Pipeline.fromFile(this.resolveRelativePath(relativeFilePath), mergedOptions.preprocessors),
+      Pipeline.fromFile(this.resolveAndSavePath(relativeFilePath), mergedOptions.preprocessors),
       mergedOptions,
     )
   }
@@ -127,7 +153,7 @@ export default class Parser {
     const mergedOptions = this.mergeOptions(options)
 
     return parseAsJSONL(
-      Pipeline.fromFile(this.resolveRelativePath(relativeFilePath), mergedOptions.preprocessors),
+      Pipeline.fromFile(this.resolveAndSavePath(relativeFilePath), mergedOptions.preprocessors),
       mergedOptions,
     )
   }
@@ -140,7 +166,7 @@ export default class Parser {
     const mergedOptions = this.mergeOptions(options)
 
     return parseAsHTML(
-      Pipeline.fromFile(this.resolveRelativePath(relativeFilePath), mergedOptions.preprocessors),
+      Pipeline.fromFile(this.resolveAndSavePath(relativeFilePath), mergedOptions.preprocessors),
       mergedOptions,
     )
   }
@@ -156,7 +182,7 @@ export default class Parser {
     const mergedOptions = this.mergeOptions(options)
 
     return parseAsCSV(
-      Pipeline.fromFile(this.resolveRelativePath(relativeFilePath), mergedOptions.preprocessors),
+      Pipeline.fromFile(this.resolveAndSavePath(relativeFilePath), mergedOptions.preprocessors),
       mergedOptions,
     )
   }
@@ -169,7 +195,7 @@ export default class Parser {
     const mergedOptions = this.mergeOptions(options)
 
     return parseAsMBOX(
-      Pipeline.fromFile(this.resolveRelativePath(relativeFilePath), mergedOptions.preprocessors),
+      Pipeline.fromFile(this.resolveAndSavePath(relativeFilePath), mergedOptions.preprocessors),
       mergedOptions,
     )
   }
@@ -182,7 +208,7 @@ export default class Parser {
     const mergedOptions = this.mergeOptions(options)
 
     return parseAsVCARD(
-      Pipeline.fromFile(this.resolveRelativePath(relativeFilePath), mergedOptions.preprocessors),
+      Pipeline.fromFile(this.resolveAndSavePath(relativeFilePath), mergedOptions.preprocessors),
       mergedOptions,
     )
   }
@@ -195,7 +221,7 @@ export default class Parser {
     const mergedOptions = this.mergeOptions(options)
 
     return parseAsICS(
-      Pipeline.fromFile(this.resolveRelativePath(relativeFilePath), mergedOptions.preprocessors),
+      Pipeline.fromFile(this.resolveAndSavePath(relativeFilePath), mergedOptions.preprocessors),
       mergedOptions,
     )
   }

--- a/src/classes/Parser.ts
+++ b/src/classes/Parser.ts
@@ -1,6 +1,13 @@
 import path from 'path'
 import { JSDOM } from 'jsdom'
-import { FilterOptions, PaginationOptions, ParsingOptions, Preprocessor, PreprocessorOptions } from '../types/Parsing'
+import {
+  FilterOptions,
+  FullParsingOptions,
+  PaginationOptions,
+  ParsingOptions,
+  Preprocessor,
+  PreprocessorOptions,
+} from '../types/Parsing'
 import listFiles, { OptionsListFiles } from '../modules/Parsing/listFiles'
 import findFiles from '../modules/Parsing/findFiles'
 import parseDir, { OptionsParseDir } from '../modules/Parsing/parseDir'
@@ -25,6 +32,13 @@ export default class Parser {
    */
   readonly parsedFiles: Array<string> = []
 
+  defaultOptions: ParsingOptions & PaginationOptions = {
+    pagination: {
+      offset: 0,
+      items: 50,
+    },
+  }
+
   constructor(extractedArchivePath: string, preprocessors: Array<Preprocessor> = []) {
     this.path = extractedArchivePath
     this.preprocessors = preprocessors
@@ -48,6 +62,17 @@ export default class Parser {
     this.savePath(absolutePath)
 
     return absolutePath
+  }
+
+  /**
+   * Merge given options with this Parser default options
+   * Default options are given to each parsing methods of this Parser
+   */
+  mergeWithDefaultOptions(options: ParsingOptions & PaginationOptions): void {
+    this.defaultOptions = {
+      ...this.defaultOptions,
+      ...options,
+    }
   }
 
   /**
@@ -78,11 +103,7 @@ export default class Parser {
    */
   mergeOptions(options?: FullParsingOptions): FullParsingOptions {
     return {
-      // Default pagination option values
-      pagination: {
-        offset: 0,
-        items: 50,
-      },
+      ...this.defaultOptions,
       ...options,
       preprocessors: options?.preprocessors ? this.preprocessors.concat(options.preprocessors) : this.preprocessors,
     }

--- a/src/classes/Parser.ts
+++ b/src/classes/Parser.ts
@@ -76,9 +76,7 @@ export default class Parser {
   /**
    * Merge parsing options with default Parser options
    */
-  mergeOptions(
-    options?: ParsingOptions & PreprocessorOptions & PaginationOptions,
-  ): ParsingOptions & PreprocessorOptions & PaginationOptions {
+  mergeOptions(options?: FullParsingOptions): FullParsingOptions {
     return {
       // Default pagination option values
       pagination: {

--- a/src/classes/Standardizer/Standardizer.ts
+++ b/src/classes/Standardizer/Standardizer.ts
@@ -61,6 +61,13 @@ export default abstract class Standardizer {
    */
   abstract get subStandardizers(): Array<Standardizer>
 
+  /**
+   * Return cloned instance of Parser, must be use by getters to keep track of parsed files
+   */
+  newParser(): Parser {
+    return this.parser.clone()
+  }
+
   async getProfile(options?: GetterOptions): GetterReturn<Profile> {
     return Promise.resolve(null)
   }

--- a/src/classes/Standardizer/Standardizer.ts
+++ b/src/classes/Standardizer/Standardizer.ts
@@ -32,6 +32,7 @@ import { GetterOptions } from '../../types/standardizer/Standardizer'
 import GetterReturn from '../../types/standardizer/GetterReturn'
 import { MediaType } from '../../types/schemas/Media'
 import Getters from '../../types/standardizer/Getters'
+import { PaginationOptions, ParsingOptions } from '../../types/Parsing'
 
 export const PLUGINS_DIR = 'plugins'
 export const EXTERNAL_GETTERS_DIR = 'getters'
@@ -64,8 +65,14 @@ export default abstract class Standardizer {
   /**
    * Return cloned instance of Parser, must be use by getters to keep track of parsed files
    */
-  newParser(): Parser {
-    return this.parser.clone()
+  newParser(defaultOptions?: ParsingOptions & PaginationOptions): Parser {
+    const newParser = this.parser.clone()
+
+    if (defaultOptions) {
+      newParser.mergeWithDefaultOptions(defaultOptions)
+    }
+
+    return newParser
   }
 
   async getProfile(options?: GetterOptions): GetterReturn<Profile> {

--- a/src/classes/Standardizer/plugins/Facebook/getters/getPosts.ts
+++ b/src/classes/Standardizer/plugins/Facebook/getters/getPosts.ts
@@ -1,5 +1,6 @@
 import Facebook from '../Facebook'
 import { Post } from '../../../../../types/schemas'
+import withAutoParser from '../../../../../modules/Standardizer/withAutoParser'
 
 const ACCOUNT_ACTIVITY_FILE = 'posts/your_posts_1.json'
 
@@ -25,10 +26,10 @@ interface FBPost {
   title: string
 }
 
-Facebook.prototype.getPosts = async function getPosts(options) {
-  const postList = await this.parser.parseAsJSON<Array<FBPost>>(ACCOUNT_ACTIVITY_FILE, options?.parsingOptions)
+Facebook.prototype.getPosts = withAutoParser(async parser => {
+  const postList = await parser.parseAsJSON<Array<FBPost>>(ACCOUNT_ACTIVITY_FILE)
 
-  const posts : Array<Post> = postList.map((post) => {
+  const posts: Array<Post> = postList.map((post) => {
     const externalLink = post?.attachments?.[0]?.data?.[0].external_context?.url
     return {
       creationDate: new Date(post.timestamp * 1000),
@@ -41,8 +42,5 @@ Facebook.prototype.getPosts = async function getPosts(options) {
     }
   })
 
-  return {
-    data: posts,
-    parsedFiles: [ACCOUNT_ACTIVITY_FILE],
-  }
-}
+  return posts
+})

--- a/src/modules/Standardizer/withAutoParser.ts
+++ b/src/modules/Standardizer/withAutoParser.ts
@@ -1,0 +1,23 @@
+import Getter from '../../types/standardizer/Getter'
+import Standardizer from '../../classes/Standardizer/Standardizer'
+import { GetterOptions } from '../../types/standardizer/Standardizer'
+import GetterReturn from '../../types/standardizer/GetterReturn'
+import Parser from '../../classes/Parser'
+
+export type WrappedGetter<T> = (this: Standardizer, parser: Parser, options?: GetterOptions) => Promise<T>
+
+export default function withAutoParser<T>(externalGetter: WrappedGetter<T>): Getter<T> {
+  return async function (this: Standardizer, options?: GetterOptions): GetterReturn<T> {
+    const parser = this.newParser()
+    const boundGetter = externalGetter.bind(this)
+
+    if (options?.parsingOptions) {
+      parser.mergeWithDefaultOptions(options.parsingOptions)
+    }
+
+    return {
+      data: await boundGetter(parser, options),
+      parsedFiles: parser.parsedFiles,
+    }
+  }
+}

--- a/src/modules/Standardizer/withAutoParser.ts
+++ b/src/modules/Standardizer/withAutoParser.ts
@@ -8,12 +8,8 @@ export type WrappedGetter<T> = (this: Standardizer, parser: Parser, options?: Ge
 
 export default function withAutoParser<T>(externalGetter: WrappedGetter<T>): Getter<T> {
   return async function (this: Standardizer, options?: GetterOptions): GetterReturn<T> {
-    const parser = this.newParser()
+    const parser = this.newParser(options?.parsingOptions)
     const boundGetter = externalGetter.bind(this)
-
-    if (options?.parsingOptions) {
-      parser.mergeWithDefaultOptions(options.parsingOptions)
-    }
 
     return {
       data: await boundGetter(parser, options),

--- a/src/types/Parsing.ts
+++ b/src/types/Parsing.ts
@@ -18,7 +18,6 @@ export interface PreprocessorOptions {
   preprocessors?: Array<Preprocessor>
 }
 
-
 export interface ParsingOptions {
 }
 

--- a/src/types/Parsing.ts
+++ b/src/types/Parsing.ts
@@ -18,5 +18,8 @@ export interface PreprocessorOptions {
   preprocessors?: Array<Preprocessor>
 }
 
+
 export interface ParsingOptions {
 }
+
+export type FullParsingOptions = ParsingOptions & PreprocessorOptions & PaginationOptions


### PR DESCRIPTION
Little helper to avoid manual parsed files tracking and parsing options management :wink:

### Example

Before:
```ts
Facebook.prototype.getPosts = async function getPosts(options) {
  const postList = await this.parser.parseAsJSON<Array<FBPost>>(ACCOUNT_ACTIVITY_FILE, options?.parsingOptions)

  const posts : Array<Post> = postList.map((post) => {
    const externalLink = post?.attachments?.[0]?.data?.[0].external_context?.url
    return {
      creationDate: new Date(post.timestamp * 1000),
      title: post?.title,
      sender: 'Myself',
      content: post?.data?.[0]?.post,
      metaData: {
        links: externalLink ? [externalLink] : undefined,
      },
    }
  })

  return {
    data: posts,
    parsedFiles: [ACCOUNT_ACTIVITY_FILE],
  }
}
```

After:
```ts
Facebook.prototype.getPosts = withAutoParser(async parser => {
  const postList = await parser.parseAsJSON<Array<FBPost>>(ACCOUNT_ACTIVITY_FILE)

  const posts: Array<Post> = postList.map((post) => {
    const externalLink = post?.attachments?.[0]?.data?.[0].external_context?.url
    return {
      creationDate: new Date(post.timestamp * 1000),
      title: post?.title,
      sender: 'Myself',
      content: post?.data?.[0]?.post,
      metaData: {
        links: externalLink ? [externalLink] : undefined,
      },
    }
  })

  return posts
})
```

### Changes

* feat(Parser): add parsed files tracking
* feat(Parser): add clone method
* feat(Standardizer): add method to get clone of Parser
* refactor(Parser): use new FullParsingOptions type
* feat(Parser): add editable default parsing options
* feat(Standardizer): add helper to auto manage Parser in external getters
* refactor(Facebook-getters): use withAutoParser helper in post getter
